### PR TITLE
Use ethers.Contract and provider fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,12 @@ export class FIAT {
     return contract;
   }
 
+  #getContractFactory(artifact, address) {
+    const contract = new ethers.ContractFactory(artifact.abi, artifact.bytecode, this.signer).attach(address);
+    contract.abi = artifact.abi;
+    return contract;
+  }
+
   getContracts() {
     return {
       aer: this.#getContract(Aer, this.addresses['aer'].address),
@@ -153,6 +159,25 @@ export class FIAT {
       vaultFCActions: this.#getContract(VaultFCActions, this.addresses['vaultFCActions'].address),
       vaultFYActions: this.#getContract(VaultFYActions, this.addresses['vaultFYActions'].address),
       vaultSPTActions: this.#getContract(VaultSPTActions, this.addresses['vaultSPTActions'].address)
+    }
+  }
+
+  getContractFactories() {
+    return {
+      aer: this.#getContractFactory(Aer, this.addresses['aer'].address),
+      codex: this.#getContractFactory(Codex, this.addresses['codex'].address),
+      limes: this.#getContractFactory(Limes, this.addresses['limes'].address),
+      moneta: this.#getContractFactory(Moneta, this.addresses['moneta'].address),
+      publican: this.#getContractFactory(Publican, this.addresses['publican'].address),
+      fiat: this.#getContractFactory(FIATToken, this.addresses['fiat'].address),
+      collybus: this.#getContractFactory(Collybus, this.addresses['collybus'].address),
+      flash: this.#getContractFactory(Flash, this.addresses['flash'].address),
+      noLossCollateralAuction: this.#getContractFactory(NoLossCollateralAuction, this.addresses['collateralAuction'].address),
+      proxyRegistry: this.#getContractFactory(PRBProxyRegistry, this.addresses['proxyRegistry'].address),
+      vaultEPTActions: this.#getContractFactory(VaultEPTActions, this.addresses['vaultEPTActions'].address),
+      vaultFCActions: this.#getContractFactory(VaultFCActions, this.addresses['vaultFCActions'].address),
+      vaultFYActions: this.#getContractFactory(VaultFYActions, this.addresses['vaultFYActions'].address),
+      vaultSPTActions: this.#getContractFactory(VaultSPTActions, this.addresses['vaultSPTActions'].address)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -132,7 +132,7 @@ export class FIAT {
   }
 
   #getContract(artifact, address) {
-    const contract = new ethers.ContractFactory(artifact.abi, artifact.bytecode, this.signer).attach(address);
+    const contract = new ethers.Contract(address, artifact.abi, this.signer ?? this.provider)
     contract.abi = artifact.abi;
     return contract;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -132,12 +132,11 @@ export class FIAT {
   }
 
   #getContract(artifact, address) {
-    const contract = new ethers.Contract(address, artifact.abi, this.signer ?? this.provider)
-    contract.abi = artifact.abi;
-    return contract;
-  }
-
-  #getContractFactory(artifact, address) {
+    if (!this.signer) {
+      const contract = new ethers.Contract(address, artifact.abi, this.provider)
+      contract.abi = artifact.abi;
+      return contract;
+    }
     const contract = new ethers.ContractFactory(artifact.abi, artifact.bytecode, this.signer).attach(address);
     contract.abi = artifact.abi;
     return contract;
@@ -159,25 +158,6 @@ export class FIAT {
       vaultFCActions: this.#getContract(VaultFCActions, this.addresses['vaultFCActions'].address),
       vaultFYActions: this.#getContract(VaultFYActions, this.addresses['vaultFYActions'].address),
       vaultSPTActions: this.#getContract(VaultSPTActions, this.addresses['vaultSPTActions'].address)
-    }
-  }
-
-  getContractFactories() {
-    return {
-      aer: this.#getContractFactory(Aer, this.addresses['aer'].address),
-      codex: this.#getContractFactory(Codex, this.addresses['codex'].address),
-      limes: this.#getContractFactory(Limes, this.addresses['limes'].address),
-      moneta: this.#getContractFactory(Moneta, this.addresses['moneta'].address),
-      publican: this.#getContractFactory(Publican, this.addresses['publican'].address),
-      fiat: this.#getContractFactory(FIATToken, this.addresses['fiat'].address),
-      collybus: this.#getContractFactory(Collybus, this.addresses['collybus'].address),
-      flash: this.#getContractFactory(Flash, this.addresses['flash'].address),
-      noLossCollateralAuction: this.#getContractFactory(NoLossCollateralAuction, this.addresses['collateralAuction'].address),
-      proxyRegistry: this.#getContractFactory(PRBProxyRegistry, this.addresses['proxyRegistry'].address),
-      vaultEPTActions: this.#getContractFactory(VaultEPTActions, this.addresses['vaultEPTActions'].address),
-      vaultFCActions: this.#getContractFactory(VaultFCActions, this.addresses['vaultFCActions'].address),
-      vaultFYActions: this.#getContractFactory(VaultFYActions, this.addresses['vaultFYActions'].address),
-      vaultSPTActions: this.#getContractFactory(VaultSPTActions, this.addresses['vaultSPTActions'].address)
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -81,6 +81,7 @@ describe('FIAT', () => {
 
   let fiat;
   let contracts;
+  let contractFactories;
   let collateralTypeData;
   let positionData;
   let healthFactor;
@@ -137,8 +138,22 @@ describe('FIAT', () => {
     expect(Object.values(contracts).length).toBeGreaterThan(0);
   });
 
+  test('getContractFactories', () => {
+    contractFactories = fiat.getContractFactories();
+    expect(Object.values(contractFactories).length).toBeGreaterThan(0);
+  });
+
   test('call', async () => {
     expect((await fiat.call(contracts.codex, 'globalDebt')).gt(0)).toBe(true);
+  });
+
+  test('callProvider', async () => {
+    const fiat_ = await FIAT.fromProvider(provider);
+    expect((await fiat_.call(contracts.codex, 'globalDebt')).gt(0)).toBe(true);
+  });
+
+  test('callFactory', async () => {
+    expect((await fiat.call(contractFactories.codex, 'globalDebt')).gt(0)).toBe(true);
   });
 
   test('multicall', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -81,7 +81,6 @@ describe('FIAT', () => {
 
   let fiat;
   let contracts;
-  let contractFactories;
   let collateralTypeData;
   let positionData;
   let healthFactor;

--- a/test/test.js
+++ b/test/test.js
@@ -138,9 +138,10 @@ describe('FIAT', () => {
     expect(Object.values(contracts).length).toBeGreaterThan(0);
   });
 
-  test('getContractFactories', () => {
-    contractFactories = fiat.getContractFactories();
-    expect(Object.values(contractFactories).length).toBeGreaterThan(0);
+  test('getContractsFromProvider', async () => {
+    const fiat_ = await FIAT.fromProvider(provider);
+    const contractsFromProvider = fiat.getContracts();
+    expect(Object.values(contractsFromProvider).length).toBeGreaterThan(0);
   });
 
   test('call', async () => {
@@ -150,10 +151,6 @@ describe('FIAT', () => {
   test('callProvider', async () => {
     const fiat_ = await FIAT.fromProvider(provider);
     expect((await fiat_.call(contracts.codex, 'globalDebt')).gt(0)).toBe(true);
-  });
-
-  test('callFactory', async () => {
-    expect((await fiat.call(contractFactories.codex, 'globalDebt')).gt(0)).toBe(true);
   });
 
   test('multicall', async () => {


### PR DESCRIPTION
The lever ui could not use the `fiat.call(...)` method since the contract instances are created with the ContractFactory which only uses a signer, not a provider.

If a signer is not present in the case the wallet is disconnected, the user can still make read only calls to the contracts.