### PR TITLE
Revert "Revert "Make dryrun throw error instead of return an object""

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatdao/sdk",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Javascript library for interacting with the FIAT protocol's contracts",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -276,7 +276,7 @@ export class FIAT {
           )).results[0].text_signature;
         } catch (error) {}
       }
-      return { success: false, reason, customError }
+      throw new Error(reason ?`${reason}. ${customError}` : customError);
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -232,10 +232,12 @@ describe('FIAT', () => {
     const resultSuccess = await fiat.dryrun(contracts.publican, 'collect', vault.address);
     expect(resultSuccess.success).toBe(true);
 
-    const resultError = await fiat.dryrun(vault, 'enter', 0, await fiat.signer.getAddress(), '1000');
-    expect(resultError.success).toBe(false);
-    expect(resultError.reason.includes('ERC20: insufficient-balance')).toBe(true);
-    expect(resultError.customError).toBe('Error(string)'); // note: `data` field is not returned by tenderly
+    try {
+      const resultError = await fiat.dryrun(vault, 'enter', 0, await fiat.signer.getAddress(), '1000');
+    } catch (e) {
+      expect(e.message.includes('ERC20: insufficient-balance'));
+      expect(e.message.includes('Error(string)')); // note: `data` field is not returned by tenderly
+    }
   });
 
   test('dryrunViaProxy', async () => {
@@ -247,12 +249,13 @@ describe('FIAT', () => {
     // );
     // expect(resultSuccess.success).toBe(true);
     
-    const resultError = await fiat.dryrunViaProxy(
-      proxy, vault, 'enter', 0, await fiat.signer.getAddress(), '1000', { from: proxyOwner }
-    );
-    expect(resultError.success).toBe(false);
-    expect(resultError.reason != undefined).toBe(true);
-    // expect(resultError.customError).toBe('Error(string)'); // Ganache returns stale data
+    try {
+      const resultError = await fiat.dryrunViaProxy(
+        proxy, vault, 'enter', 0, await fiat.signer.getAddress(), '1000', { from: proxyOwner }
+      );
+    } catch (e) {
+      expect(e.message).not.toBe('');
+    }
   });
 
   test('fetchCollateralTypes', async () => {


### PR DESCRIPTION
Reverts fiatdao/sdk#18

includes changes from original pr, fiatdao/sdk#17 , which makes the dryrun method throw an error when catching an exception instead of returning an object with error information
this includes the version bump